### PR TITLE
Add RouteReuseStrategy implementation for shop component navigation

### DIFF
--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {HttpClientModule, HTTP_INTERCEPTORS} from '@angular/common/http';
-
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { CoreModule } from './core/core.module';
@@ -12,8 +11,8 @@ import { ErrorInterceptor } from './core/interceptors/error.interceptor';
 import { NgxSpinnerModule } from 'ngx-spinner';
 import { LoadingInterceptor } from './core/interceptors/loading.interceptors';
 import { JwtInterceptor } from './core/interceptors/jwt.interceptor';
-
-
+import { RouteReuseStrategy } from '@angular/router';
+import { CustomRouteReuseStrategy } from './shared/routingStrategy/CustomRouteReuseStrategy';
 
 @NgModule({
   declarations: [
@@ -34,6 +33,7 @@ import { JwtInterceptor } from './core/interceptors/jwt.interceptor';
     {provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true},
     {provide: HTTP_INTERCEPTORS, useClass: LoadingInterceptor, multi: true},
     {provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true},
+    {provide: RouteReuseStrategy, useClass: CustomRouteReuseStrategy},
   ],
   bootstrap: [AppComponent]
 })

--- a/client/src/app/shared/routingStrategy/CustomRouteReuseStrategy.ts
+++ b/client/src/app/shared/routingStrategy/CustomRouteReuseStrategy.ts
@@ -1,0 +1,107 @@
+import { RouteReuseStrategy, DetachedRouteHandle, ActivatedRouteSnapshot } from '@angular/router';
+import { ComponentRef, Injectable } from '@angular/core';
+
+@Injectable()
+export class CustomRouteReuseStrategy implements RouteReuseStrategy {
+  private handlers: { [key: string]: RootHandler } = {};
+  shouldDetach(route: ActivatedRouteSnapshot): boolean {
+    return this.isDetachable(route);
+  }
+
+  store(route: ActivatedRouteSnapshot, handler: DetachedRouteHandle) {
+    const storeKey =  this.getStoreKey(route);
+    if (handler) {
+      // I need to keep track of the time the route is stored so I added storeTime.
+      const rootHandler = {
+        handle: handler,
+        storeTime: +new Date()
+      };
+      this.handlers[storeKey] = rootHandler;
+    }
+  }
+
+  shouldAttach(route: ActivatedRouteSnapshot): boolean {
+    const storeKey =  this.getStoreKey(route);
+    if (this.isAtachable(route, storeKey)) {
+      // you can retrun true only
+      // clearNewerHandlerOnAttach is optional
+      // when load the snapshot (attach old route) I only want to keep routes stored before this route
+      // and delete routes stored after this route.
+      // for exmaple, if i go to product list and then product detail and then saler information
+      // if product list, product detail and saler information are all detachable.
+      // when I back from saler information to product detail I don't want to store saler information
+      // and when I back from product detail to product list I don't want to store product detail route
+      // because I when I go back to product list and then go to the same product detail again
+      // I want to load new data. Why?
+      // I think people rarely go back and fort 2 pages multiple time
+      // by deleting unnecessary stored route we save memory.
+      this.clearNewerHandlerOnAttach(this.handlers[storeKey].storeTime);
+      return true;
+    }
+    return false;
+  }
+
+  retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle {
+    const storeKey =  this.getStoreKey(route);
+    return this.handlers[storeKey]?.handle;
+  }
+
+  shouldReuseRoute( future: ActivatedRouteSnapshot, current: ActivatedRouteSnapshot): boolean {
+    return future.routeConfig === current.routeConfig;
+  }
+
+  private getResolvedUrl(route: ActivatedRouteSnapshot): string {
+    return route.pathFromRoot
+        .map(v => v.url.map(segment => segment.toString()).join('/'))
+        .join('/');
+  }
+
+  private getStoreKey(route: ActivatedRouteSnapshot): string {
+    const baseUrl = this.getResolvedUrl(route);
+    const childrenParts = [];
+    let deepestChild = route;
+    while (deepestChild.firstChild) {
+        deepestChild = deepestChild.firstChild;
+        childrenParts.push(deepestChild.url.join('/'));
+    }
+    return baseUrl + '////' + childrenParts.join('/');
+  }
+
+  // true if we mark this route shouldDetach:true
+  // see it in route config
+  private isDetachable(route: ActivatedRouteSnapshot) {
+    if ( route?.routeConfig?.data?.shouldDetach) {
+      return true;
+    }
+    return false;
+  }
+
+  private isAtachable(route: ActivatedRouteSnapshot, storeKey: string) {
+    if (this.isDetachable(route) && this.handlers[storeKey]?.handle) {
+      return true;
+    }
+    return false;
+  }
+
+  /*
+  When the user goes back (attach a root)
+  I want to clear newer stored roots.
+  */
+  private clearNewerHandlerOnAttach(storeTime: number) {
+    const handlerKeys = Object.keys(this.handlers);
+    handlerKeys.forEach(k => {
+      if (this.handlers[k].storeTime > storeTime) {
+        const componentRef: ComponentRef<any> = (this.handlers[k].handle as any).componentRef;
+        if (componentRef) {
+          componentRef.destroy();
+        }
+        delete this.handlers[k];
+      }
+    });
+  }
+}
+
+export interface RootHandler {
+  handle: DetachedRouteHandle;
+  storeTime: number;
+}

--- a/client/src/app/shop/shop-routing.module.ts
+++ b/client/src/app/shop/shop-routing.module.ts
@@ -1,12 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule, Routes } from '@angular/router';
-  import { ShopComponent } from './shop.component';
-  import { ProductDetailsComponent } from './product-details/product-details.component';
+import { ShopComponent } from './shop.component';
+import { ProductDetailsComponent } from './product-details/product-details.component';
+import { RouteReuseStrategy, RouterModule, Routes } from '@angular/router';
+
 
 const routes: Routes = [
-  
-  {path:'', component: ShopComponent},
+
+  //Use of RouteReuseStrategy to "save" component state when we navigate from shop to individual products to save resources.
+  {path:'', component: ShopComponent, data: {shouldDetach: true}},
   {path: ':id', component: ProductDetailsComponent, data: {breadcrumb: {alias: 'productDetails'}}},
 ];
 
@@ -17,6 +19,6 @@ const routes: Routes = [
   ],
   exports: [
     RouterModule
-  ]
+  ],
 })
 export class ShopRoutingModule { }

--- a/client/src/app/shop/shop.component.ts
+++ b/client/src/app/shop/shop.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild, OnDestroy } from '@angular/core';
 import { IBrand } from '../shared/models/brands';
 import { IProduct } from '../shared/models/product';
 import { IProductType } from '../shared/models/productType';
@@ -43,7 +43,8 @@ import {
   ]
 
 })
-export class ShopComponent implements OnInit {
+export class ShopComponent implements OnInit, OnDestroy {
+
   @ViewChild('search', {static: false}) searchTerm: ElementRef;
   products: IProduct[];
   brands: IBrand[];
@@ -88,6 +89,8 @@ export class ShopComponent implements OnInit {
     this.getProducts(true);
     this.getBrands();
     this.getProductTypes();
+
+    console.log('ShopComponent::ngOnInit');
   }
 
   getProducts(useCache = false) {
@@ -116,41 +119,43 @@ export class ShopComponent implements OnInit {
     });
   }
 
-  onBrandSelected(brandId: number) {
-    const params = this.shopService.getShopParams();
-    params.brandIds.push(brandId);
-    params.pageNumber = 1;
-    this.shopService.setShopParams(params);
-    this.getProducts();
-  }
+  // Old version of filtering
+  // onBrandSelected(brandId: number) {
+  //   const params = this.shopService.getShopParams();
+  //   params.brandIds.push(brandId);
+  //   params.pageNumber = 1;
+  //   this.shopService.setShopParams(params);
+  //   this.getProducts();
+  // }
 
-  onTypeSelected(typeId: number){
-    const params = this.shopService.getShopParams();
-    params.typeIds.push(typeId);
-    params.pageNumber = 1;
-    this.shopService.setShopParams(params);
-    this.getProducts();
-  }
+  // onTypeSelected(typeId: number){
+  //   const params = this.shopService.getShopParams();
+  //   params.typeIds.push(typeId);
+  //   params.pageNumber = 1;
+  //   this.shopService.setShopParams(params);
+  //   this.getProducts();
+  // }
 
   //Filter Checkbox testing
   getCheckboxValuesForProductTypes(event, typeId){
     const params = this.shopService.getShopParams();
-    if(event.target.checked){
+
+    if(event.target.checked) {
       params.typeIds.push(typeId);
     }
     else {
       let indexOfTypeId = params.typeIds.indexOf(typeId);
-
       if(indexOfTypeId != -1)
       {
-        params.typeIds.splice(indexOfTypeId,1);
+        params.typeIds.splice(indexOfTypeId, 1);
       }
     }
+
     params.pageNumber = 1;
     this.shopService.setShopParams(params);
     this.getProducts();
-
   }
+
 
   getCheckboxValuesForBrandTypes(event, brandId){
     const params = this.shopService.getShopParams();
@@ -207,4 +212,8 @@ export class ShopComponent implements OnInit {
     this.getProducts();
   }
 
+
+  ngOnDestroy() : void {
+    console.log('ShopComponent::ngOnDestroy')
+  }
 }

--- a/client/src/app/shop/shop.service.ts
+++ b/client/src/app/shop/shop.service.ts
@@ -21,6 +21,8 @@ export class ShopService {
   pagination = new Pagination();
   shopParams = new ShopParams();
   productCache = new Map();
+  productTypeIdCheckboxStorage: number[] = [];
+
 
   constructor(private http: HttpClient) { }
 
@@ -119,4 +121,24 @@ export class ShopService {
       })
     );
   }
+
+  addCheckboxValueProductTypes(event, typeId) {
+    if(event.target.checked) {
+      this.productTypeIdCheckboxStorage.push(typeId);
+    }
+    else {
+      console.log("This is fired");
+      let indexOfTypeId = this.productTypeIdCheckboxStorage.indexOf(typeId);
+
+      this.productTypeIdCheckboxStorage.splice(indexOfTypeId,1);
+
+      // if(indexOfTypeId != -1)
+      // {
+      //   this.productTypeIdCheckboxStorage.splice(indexOfTypeId,1);
+      // }
+    }
+
+  }
+
+
 }


### PR DESCRIPTION
Added custom implementation for Route reuse so to preserve the state of the shop when navigating to product details pages
and back to the shop again. This saves resources, less API calls and feels more natural when navigating the shop. 