### PR TITLE
Fixed product image display issue in order history section.

### DIFF
--- a/API/Helpers/OrderItemUrlResolver.cs
+++ b/API/Helpers/OrderItemUrlResolver.cs
@@ -17,7 +17,7 @@ namespace API.Helpers
         {
             if (!string.IsNullOrEmpty(source.ItemOrdered.PictureUrl))
             {
-                return _config["ApiUrl"] + source.ItemOrdered.PictureUrl;
+                return source.ItemOrdered.PictureUrl;
             }
 
             return null;

--- a/API/Helpers/ProductUrlResolver.cs
+++ b/API/Helpers/ProductUrlResolver.cs
@@ -26,13 +26,13 @@ namespace API.Helpers
                 //return photo.PictureUrl;
                 if(photo.PictureUrl.Contains("images"))
                 {
-                    return _config["ApiUrl"] + photo.PictureUrl;
+                    return photo.PictureUrl;
                 }
                 return photo.PictureUrl;
 
             }
 
-            return _config["ApiUrl"] + "images/products/placeholder.png";
+            return "images/products/placeholder.png";
         }
     }
 }

--- a/Core/Entities/Product.cs
+++ b/Core/Entities/Product.cs
@@ -64,7 +64,10 @@ namespace Core.Entities
             if (photo != null)
             {
                 photo.IsMain = true;
-                if (currentMain != null) currentMain.IsMain = false;
+                if (currentMain != null)
+                {
+                    currentMain.IsMain = false;
+                } 
             }
         }
     }

--- a/Infrastructure/Services/OrderService.cs
+++ b/Infrastructure/Services/OrderService.cs
@@ -31,7 +31,13 @@ namespace Infrastructure.Services
             var items = new List<OrderItem>();
             foreach(var item in basket.Items)
             {
-                var productItem = await _unitOfWork.Repository<Product>().GetByIdAsync(item.Id);
+
+                var specificationForProduct = new ProductsWithTypesAndBrandsSpecification(item.Id);
+
+                //var product = await _unitOfWork.Repository<Product>().GetEntityWithSpecification(specificationForProduct);
+
+                var productItem = await _unitOfWork.Repository<Product>().GetEntityWithSpecification(specificationForProduct);
+                //var productItem = await _unitOfWork.Repository<Product>().GetByIdAsync(item.Id);
                 var itemOrdered = new ProductItemOrdered(productItem.Id, productItem.Name, productItem.Photos.FirstOrDefault(x => x.IsMain)?.PictureUrl);
                 var orderItem = new OrderItem(itemOrdered, productItem.Price, item.Quantity);
                 items.Add(orderItem);


### PR DESCRIPTION
Product images now correctly displays in the order history section. Resorted issue with accessing images correctly to corresponding product Id when a new order was created. 